### PR TITLE
Addon versions: Change versions of addons '1.0.0' to '0.1.0'

### DIFF
--- a/applications/dev/__init__.py
+++ b/applications/dev/__init__.py
@@ -31,7 +31,7 @@ def get_enum_items_from_groups(groups):
 
 class ApplicationsAddon(BaseServerAddon):
     name = "applications"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model = ApplicationsAddonSettings
 
     async def get_default_settings(self):

--- a/blender/dev/__init__.py
+++ b/blender/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import BlenderSettings, DEFAULT_VALUES
 class BlenderAddon(BaseServerAddon):
     name = "blender"
     title = "Blender"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[BlenderSettings] = BlenderSettings
     frontend_scopes = {}
     services = {}

--- a/celaction/dev/__init__.py
+++ b/celaction/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import CelActionSettings, DEFAULT_VALUES
 class CelActionAddon(BaseServerAddon):
     name = "celaction"
     title = "CelAction"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[CelActionSettings] = CelActionSettings
     frontend_scopes = {}
     services = {}

--- a/clockify/dev/__init__.py
+++ b/clockify/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import ClockifySettings
 class ClockifyAddon(BaseServerAddon):
     name = "clockify"
     title = "Clockify"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[ClockifySettings] = ClockifySettings
     frontend_scopes = {}
     services = {}

--- a/core/dev/__init__.py
+++ b/core/dev/__init__.py
@@ -4,7 +4,7 @@ from .settings import CoreSettings, DEFAULT_VALUES
 
 class CoreAddon(BaseServerAddon):
     name = "core"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model = CoreSettings
 
     async def get_default_settings(self):

--- a/deadline/dev/__init__.py
+++ b/deadline/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import DeadlineSettings, DEFAULT_VALUES
 class Deadline(BaseServerAddon):
     name = "deadline"
     title = "Deadline"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[DeadlineSettings] = DeadlineSettings
 
     async def get_default_settings(self):

--- a/flame/dev/__init__.py
+++ b/flame/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import FlameSettings, DEFAULT_VALUES
 class FlameAddon(BaseServerAddon):
     name = "flame"
     title = "Flame"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[FlameSettings] = FlameSettings
     frontend_scopes = {}
     services = {}

--- a/fusion/dev/__init__.py
+++ b/fusion/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import FusionSettings, DEFAULT_VALUES
 class FusionAddon(BaseServerAddon):
     name = "fusion"
     title = "Fusion"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[FusionSettings] = FusionSettings 
     frontend_scopes = {}
     services = {}

--- a/hiero/dev/__init__.py
+++ b/hiero/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import HieroSettings, DEFAULT_VALUES
 class HieroAddon(BaseServerAddon):
     name = "hiero"
     title = "Hiero"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[HieroSettings] = HieroSettings
     frontend_scopes = {}
     services = {}

--- a/houdini/dev/__init__.py
+++ b/houdini/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import HoudiniSettings, DEFAULT_VALUES
 class Houdini(BaseServerAddon):
     name = "houdini"
     title = "Houdini"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[HoudiniSettings] = HoudiniSettings
 
     async def get_default_settings(self):

--- a/kitsu/dev/__init__.py
+++ b/kitsu/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import KitsuSettings, DEFAULT_VALUES
 class KitsuAddon(BaseServerAddon):
     name = "kitsu"
     title = "Kitsu"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[KitsuSettings] = KitsuSettings
     frontend_scopes = {}
     services = {}

--- a/maya/dev/version.py
+++ b/maya/dev/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "1.0.0"
+__version__ = "0.1.0"

--- a/muster/dev/__init__.py
+++ b/muster/dev/__init__.py
@@ -7,7 +7,7 @@ from .settings import MusterSettings, DEFAULT_VALUES
 
 class MusterAddon(BaseServerAddon):
     name = "muster"
-    version = "1.0.0"
+    version = "0.1.0"
     title = "Muster"
     settings_model: Type[MusterSettings] = MusterSettings
 

--- a/nuke/dev/__init__.py
+++ b/nuke/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import NukeSettings, DEFAULT_VALUES
 class NukeAddon(BaseServerAddon):
     name = "nuke"
     title = "Nuke"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[NukeSettings] = NukeSettings
 
     async def get_default_settings(self):

--- a/resolve/dev/__init__.py
+++ b/resolve/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import ResolveSettings, DEFAULT_VALUES
 class ResolveAddon(BaseServerAddon):
     name = "resolve"
     title = "DaVinci Resolve"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[ResolveSettings] = ResolveSettings
     frontend_scopes = {}
     services = {}

--- a/royal_render/dev/__init__.py
+++ b/royal_render/dev/__init__.py
@@ -7,7 +7,7 @@ from .settings import RoyalRenderSettings, DEFAULT_VALUES
 
 class RoyalRenderAddon(BaseServerAddon):
     name = "royalrender"
-    version = "1.0.0"
+    version = "0.1.0"
     title = "Royal Render"
     settings_model: Type[RoyalRenderSettings] = RoyalRenderSettings
 

--- a/timers_manager/dev/__init__.py
+++ b/timers_manager/dev/__init__.py
@@ -7,6 +7,6 @@ from .settings import TimersManagerSettings
 
 class TimersManagerAddon(BaseServerAddon):
     name = "timers_manager"
-    version = "1.0.0"
+    version = "0.1.0"
     title = "Timers Manager"
     settings_model: Type[TimersManagerSettings] = TimersManagerSettings

--- a/traypublisher/dev/version.py
+++ b/traypublisher/dev/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "1.0.0"
+__version__ = "0.1.0"

--- a/tvpaint/dev/__init__.py
+++ b/tvpaint/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import TvpaintSettings, DEFAULT_VALUES
 class TvpaintAddon(BaseServerAddon):
     name = "tvpaint"
     title = "TVPaint"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[TvpaintSettings] = TvpaintSettings
     
 

--- a/unreal/dev/__init__.py
+++ b/unreal/dev/__init__.py
@@ -8,7 +8,7 @@ from .settings import UnrealSettings, DEFAULT_VALUES
 class UnrealAddon(BaseServerAddon):
     name = "unreal"
     title = "Unreal"
-    version = "1.0.0"
+    version = "0.1.0"
     settings_model: Type[UnrealSettings] = UnrealSettings
     frontend_scopes = {}
     services = {}


### PR DESCRIPTION
## Description
We're not versioning existing addons right now which causes a lot of troubles as it is hard to help others where is the issue if we can't ask "which version of addons you have on server", also the addons probably should not have yet version starting with `1.x.x`. From this onward we should change addon version on addon change.